### PR TITLE
Refactor: admin routes now all residing within namespace

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,12 +7,9 @@ Rails.application.routes.draw do
     resources :invoices, only: [:index, :show], controller: "merchants/invoices"
   end
 
-  resource :admin, only: :index do
-    resources :merchants, only: [:index, :show], controller: "admin/merchants"
-    resources :invoices, only: [:index, :show], controller: "admin/invoices"
-  end
-    
   namespace :admin do
     get '/', to: 'dashboard#index'
+    resources :merchants, only: [:index, :show]
+    resources :invoices, only: [:index, :show]
   end
 end


### PR DESCRIPTION
refactored routes for admin to now work within namespace: the namespace allows the mixin to match to the proper directories so that `controller: <path>` is no longer necessary.